### PR TITLE
Builder cross

### DIFF
--- a/builder-cross/Dockerfile
+++ b/builder-cross/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.4-cross
+MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
+
+# Install Docker binary
+RUN wget -nv https://get.docker.com/builds/Linux/x86_64/docker-1.3.3 -O /usr/bin/docker && \
+  chmod +x /usr/bin/docker
+
+VOLUME /src
+WORKDIR /src
+
+COPY build_environment.sh /
+COPY build.sh /
+
+ENTRYPOINT ["/build.sh"]

--- a/builder-cross/build.sh
+++ b/builder-cross/build.sh
@@ -16,6 +16,7 @@ for GOOS in darwin linux; do
                         --installsuffix cgo \
                         --ldflags="${LDFLAGS:--s}" \
                         $pkgName`
+                rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
         done
 done
 

--- a/builder-cross/build.sh
+++ b/builder-cross/build.sh
@@ -8,7 +8,12 @@ name=${pkgName##*/}
 for GOOS in darwin linux; do
         for GOARCH in 386 amd64; do
                 echo "Building $name for $GOOS-$GOARCH"
-                `go build \
+                # Why am I redefining the same variables that already existed?
+                # Somehow they're not available just from the loop, unless I
+                # either export them or do this. My theory is that it's somehow
+                # building in another process that doesn't have access to the
+                # loop variables. That caused everything to be built for linux.
+                `GOOS=$GOOS GOARCH=$GOARCH go build \
                         -v \
                         -o $name-$GOOS-$GOARCH \
                         $pkgName`

--- a/builder-cross/build.sh
+++ b/builder-cross/build.sh
@@ -8,13 +8,9 @@ name=${pkgName##*/}
 for GOOS in darwin linux; do
         for GOARCH in 386 amd64; do
                 echo "Building $name for $GOOS-$GOARCH"
-                # Compile statically linked version of package
-                `CGO_ENABLED=${CGO_ENABLED:-0} go build \
+                `go build \
                         -v \
                         -o $name-$GOOS-$GOARCH \
-                        -a \
-                        --installsuffix cgo \
-                        --ldflags="${LDFLAGS:--s}" \
                         $pkgName`
                 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
         done

--- a/builder-cross/build.sh
+++ b/builder-cross/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+source /build_environment.sh
+
+# Grab the last segment from the package name
+name=${pkgName##*/}
+
+for GOOS in darwin linux; do
+        for GOARCH in 386 amd64; do
+                echo "Building $name for $GOOS-$GOARCH"
+                # Compile statically linked version of package
+                `CGO_ENABLED=${CGO_ENABLED:-0} go build \
+                        -v \
+                        -o $name-$GOOS-$GOARCH \
+                        -a \
+                        --installsuffix cgo \
+                        --ldflags="${LDFLAGS:--s}" \
+                        $pkgName`
+        done
+done
+
+if [ -e "/var/run/docker.sock" ] && [ -e "./Dockerfile" ];
+then
+  # Default TAG_NAME to package name if not set explicitly
+  tagName=${tagName:-"$name":latest}
+
+  # Build the image from the Dockerfile in the package directory
+  docker build -t $tagName .
+fi

--- a/builder-cross/build_environment.sh
+++ b/builder-cross/build_environment.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+tagName=$1
+
+if ( find /src -maxdepth 0 -empty | read v );
+then
+  echo "Error: Must mount Go source code into /src directory"
+  exit 990
+fi
+
+# Grab Go package name
+pkgName="$(go list -e -f '{{.ImportComment}}' 2>/dev/null || true)"
+
+if [ -z "$pkgName" ];
+then
+  echo "Error: Must add canonical import path to root package"
+  exit 992
+fi
+
+# Grab just first path listed in GOPATH
+goPath="${GOPATH%%:*}"
+
+# Construct Go package path
+pkgPath="$goPath/src/$pkgName"
+
+# Set-up src directory tree in GOPATH
+mkdir -p "$(dirname "$pkgPath")"
+
+# Link source dir into GOPATH
+ln -sf /src "$pkgPath"
+
+if [ -e "$pkgPath/Godeps/_workspace" ];
+then
+  # Add local godeps dir to GOPATH
+  GOPATH=$pkgPath/Godeps/_workspace:$GOPATH
+else
+  # Get all package dependencies
+  go get -t -d -v ./...
+fi


### PR DESCRIPTION
I'm not 100% sure this works yet, but I want to PR it so I don't forget. I mean, I might still forget, but...

Anyway, this is really similar to the regular builder. The `Dockerfile` only differs in the Go image it descends from (really wish there was a way to source other Dockerfiles), and the build script is a stripped-down version of the regular one. I took out any flag I wasn't 100% sure worked in the cross-compiling context. Somebody else can add them if they need them and can test that they work.

This doesn't have the self-extracting stuff that just got put in the builder, but I can't imagine that thing works as-is on multiple platforms.
