### PR TITLE
Do an early exit if something breaks

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 source /build_environment.sh
 


### PR DESCRIPTION
As a coder automating my builds I want to use the golang-builder inside my Makefile or other automation to build my assets in a clean way. If the build isn't successful I want to stop the whole process in order not to do broken deployments.

This is achieved in this commit using `#!/bin/bash -e` which will ensure bash exits if any exit code is different than `0` and exit the build process with a non-zero exit code.
