### PR TITLE
allow to override cross compilation targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ The above are environment variables to be passed to the docker run command:
 
 An additional image, `centurylink/golang-builder-cross`, exists that works identically to `golang-builder` save for the presence of the additional options presented above. This uses a larger base image that will build linux and OSX binaries for 32- and 64-bit, named like `mypackage-darwin-amd64`. This will use CGO, and you may find that some code – for example things from the `os` package – do not behave the same under cross-compilation in a container as they do natively compiled in OSX.
 
+By default it will build Linux and OSX binaries for 32- and 64-bit but you can override this with environment variables.
+
+docker run --rm \
+  -e BUILD_GOOS="linux" \
+  -e BUILD_GOARCH="arm amd64" \
+  -v $(pwd):/src \
+  centurylink/golang-builder-cross
+
+This command will build Linux binaries for amd64 and arm.
+
 More information can be found in [the Docker Hub page](https://registry.hub.docker.com/_/golang/) for the official Go images.
 
 ## SSL Verification

--- a/builder-cross/build.sh
+++ b/builder-cross/build.sh
@@ -5,17 +5,20 @@ source /build_environment.sh
 # Grab the last segment from the package name
 name=${pkgName##*/}
 
-for GOOS in darwin linux; do
-        for GOARCH in 386 amd64; do
-                echo "Building $name for $GOOS-$GOARCH"
+BUILD_GOOS=${BUILD_GOOS:-"darwin linux"}
+BUILD_GOARCH=${BUILD_GOARCH:-"386 amd64"}
+
+for goos in $BUILD_GOOS; do
+        for goarch in $BUILD_GOARCH; do
+                echo "Building $name for $goos-$goarch"
                 # Why am I redefining the same variables that already existed?
                 # Somehow they're not available just from the loop, unless I
                 # either export them or do this. My theory is that it's somehow
                 # building in another process that doesn't have access to the
                 # loop variables. That caused everything to be built for linux.
-                `GOOS=$GOOS GOARCH=$GOARCH go build \
+                `GOOS=$goos GOARCH=$goarch go build \
                         -v \
-                        -o $name-$GOOS-$GOARCH \
+                        -o $name-$goos-$goarch \
                         $pkgName`
                 rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
         done


### PR DESCRIPTION
adds the possibility to pass cross-compilation targets to golang-builder-cross to allow building go binaries for arm.

the following example will build linux binaries for amd64 and arm.

```
docker run --rm \
  -e BUILD_GOOS="linux" \
  -e BUILD_GOARCH="arm amd64" \
  -v $(pwd):/src \
  centurylink/golang-builder-cross
```

it falls back to the original behaviour if no env vars are defined.

i'm using it successfully to build a dockerui image for an rpi2: https://registry.hub.docker.com/u/linki/rpi-dockerui/
