### PR TITLE
Added support for Go 1.5 vendor experiment.

### DIFF
--- a/builder-cross/build_environment.sh
+++ b/builder-cross/build_environment.sh
@@ -29,7 +29,11 @@ mkdir -p "$(dirname "$pkgPath")"
 # Link source dir into GOPATH
 ln -sf /src "$pkgPath"
 
-if [ -e "$pkgPath/Godeps/_workspace" ];
+if [ -e "$pkgPath/vendor" ];
+then
+    # Enable vendor experiment
+    export GO15VENDOREXPERIMENT=1
+elif [ -e "$pkgPath/Godeps/_workspace" ];
 then
   # Add local godeps dir to GOPATH
   GOPATH=$pkgPath/Godeps/_workspace:$GOPATH

--- a/builder/build_environment.sh
+++ b/builder/build_environment.sh
@@ -29,7 +29,11 @@ mkdir -p "$(dirname "$pkgPath")"
 # Link source dir into GOPATH
 ln -sf /src "$pkgPath"
 
-if [ -e "$pkgPath/Godeps/_workspace" ];
+if [ -e "$pkgPath/vendor" ];
+then
+    # Enable vendor experiment
+    export GO15VENDOREXPERIMENT=1
+elif [ -e "$pkgPath/Godeps/_workspace" ];
 then
   # Add local godeps dir to GOPATH
   GOPATH=$pkgPath/Godeps/_workspace:$GOPATH

--- a/tester/build_environment.sh
+++ b/tester/build_environment.sh
@@ -29,7 +29,11 @@ mkdir -p "$(dirname "$pkgPath")"
 # Link source dir into GOPATH
 ln -sf /src "$pkgPath"
 
-if [ -e "$pkgPath/Godeps/_workspace" ];
+if [ -e "$pkgPath/vendor" ];
+then
+    # Enable vendor experiment
+    export GO15VENDOREXPERIMENT=1
+elif [ -e "$pkgPath/Godeps/_workspace" ];
 then
   # Add local godeps dir to GOPATH
   GOPATH=$pkgPath/Godeps/_workspace:$GOPATH

--- a/tester/test.sh
+++ b/tester/test.sh
@@ -2,4 +2,9 @@
 
 source /build_environment.sh
 
-go test -v  ./...
+if [ "$GO15VENDOREXPERIMENT"=="1" ]; 
+then
+    go test -v $(go list ./... | grep -v /vendor/ | sed s,_/src,$pkgName,g)
+else
+    go test -v  ./...
+fi


### PR DESCRIPTION
The current implementation already supports a vendored folder created by
`godeps`. As `godeps` has support for `GO15VENDOREXPERIMENT=1`, it seems
reasonable to support this form of vendoring if it is detected.
