### PR TITLE
Support cross compilation on latest version of golang

### DIFF
--- a/builder-cross/Dockerfile
+++ b/builder-cross/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4-cross
+FROM golang:latest
 MAINTAINER CenturyLink Labs <clt-labs-futuretech@centurylink.com>
 
 # Install Docker binary


### PR DESCRIPTION
The builder-cross Dockerfile looks like its been left on an old version of golang.

The PR changes the builder to use the latest version of golang